### PR TITLE
Remove one of two ways to set wifi SSIDs. [##122987841]

### DIFF
--- a/src/lib/hostapd.rb
+++ b/src/lib/hostapd.rb
@@ -153,16 +153,11 @@ module Wifi
   Contract Hash => String
 
   def self.ssid(network)
-    # on initial setup the wifi uses a statically set name instead of the hostname.
-    # this works only for the private wifi and can be set in `hostname_path`.
-    hostname_path = File.join(network[:path], 'hostname')
     box_name_path = File.join(network[:config_root], 'box_name')
     if File.exists? box_name_path
       hostname = File.read box_name_path
-    elsif network[:name] == 'wl_private' and File.exists? hostname_path
-      hostname = File.read hostname_path
     else
-      hostname = 'Protonet'
+      hostname = 'Protonet-default'
     end
     hostname = hostname.strip
     network[:name] == 'wl_private' ? hostname : "#{ hostname } (public)"

--- a/src/test/hostapd_test.rb
+++ b/src/test/hostapd_test.rb
@@ -51,7 +51,7 @@ class HostapdTest < Minitest::Test
   end
 
   def read_hostname
-    'Protonet'
+    'Protonet-default'
   end
 
   def set_hostname(hostname = read_hostname)
@@ -140,18 +140,7 @@ class HostapdTest < Minitest::Test
     assert_includes config, "ssid=#{ hostname }"
   end
 
-  def test_private_ssid_is_taken_form_hostname_file
-    # used in initial setup only
-    hostname_file = File.join(@config_path, 'hostname')
-    File.open(hostname_file, 'w') do |file|
-      file.write('foobarblu')
-    end
-    Wifi.start @config_path, @hostapd_config_path
-    assert_includes config, "ssid=foobarblu"
-  ensure
-    File.unlink hostname_file if File.exists? hostname_file
-  end
-
+  
   def test_private_ssid_is_taken_form_box_name_file
     # used in initial setup only
     box_name_file = File.join(@config_path_base, 'box_name')


### PR DESCRIPTION
We don't actually need a separate default SSID, because there's just no way to change the box name in the initial setup screen.
